### PR TITLE
Allow library consumers to detect whether the printing dialogue was cancelled

### DIFF
--- a/RNPrint/RNPrint.m
+++ b/RNPrint/RNPrint.m
@@ -39,7 +39,7 @@ RCT_EXPORT_METHOD(print:(NSString *)filePath
             NSLog(@"Printing could not complete because of error: %@", error);
             reject(RCTErrorUnspecified, nil, RCTErrorWithMessage(error.description));
         } else {
-            resolve(printInfo.jobName);
+            resolve(printInfo.jobName, completed);
         }
     };
     

--- a/RNPrint/RNPrint.m
+++ b/RNPrint/RNPrint.m
@@ -39,7 +39,7 @@ RCT_EXPORT_METHOD(print:(NSString *)filePath
             NSLog(@"Printing could not complete because of error: %@", error);
             reject(RCTErrorUnspecified, nil, RCTErrorWithMessage(error.description));
         } else {
-            resolve(printInfo.jobName, completed);
+            resolve(completed ? printInfo.jobName : nil);
         }
     };
     


### PR DESCRIPTION
We're using React Native Print to print QR codes on a label printer. As soon as a QR code is printed, we ask the user to scan the QR code they printed to verify that everything's working.

We had a bug reported to us that users could cancel out of the print dialog and our application would still act like they had printed the QR code and ask for verification. In order to behave correctly, we need to be able to see whether the user cancelled out of the print dialog.

This PR sends back an `undefined` print job name when the user cancels. There are two other approaches I had considered:

1. Creating a class to hold the results of the print operation and passing this back. I didn't do this because it'd be quite a severe breaking change.
2. Considering cancelling an error and calling reject. This would also be a breaking change, so I avoided doing this.

I'd be happy to do either of the above if it's what you'd prefer, but I figured this would be a good way to start the conversation about how to expose cancelling back up to JS land.