### PR TITLE
Rename package in Android manifest

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.rnprint.RNPrint">
+          package="com.christopherdro.RNPrint">
 
 </manifest>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-print",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Print documents with React Native",
   "main": "index.js",
   "keywords": [


### PR DESCRIPTION
This pull request will rename the package in Android manifest so that it is linked properly when running `react-native link`.