### PR TITLE
Add `requiresMainQueueSetup` to RNPrint

### DIFF
--- a/ios/RNPrint/RNPrint.m
+++ b/ios/RNPrint/RNPrint.m
@@ -155,4 +155,9 @@ RCT_EXPORT_METHOD(selectPrinter:(RCTPromiseResolveBlock)resolve
 
 -(void)printInteractionControllerDidFinishJob:(UIPrintInteractionController*)printInteractionController {}
 
++(BOOL)requiresMainQueueSetup
+{
+  return YES;
+}
+
 @end


### PR DESCRIPTION
Patch to fix the warning described in #37. 