### PR TITLE
Added ARC related setting to Podspec

### DIFF
--- a/react-native-print.podspec
+++ b/react-native-print.podspec
@@ -2,7 +2,6 @@ require 'json'
 pjson = JSON.parse(File.read('package.json'))
 
 Pod::Spec.new do |s|
-
   s.name            = pjson["name"]
   s.version         = pjson["version"]
   s.homepage        = "https://github.com/christopherdro/react-native-print"
@@ -10,9 +9,11 @@ Pod::Spec.new do |s|
   s.license         = pjson["license"]
   s.author          = { "Christopher Dro" => "casheghian@gmail.com" }
 
+  s.requires_arc   = true
+  s.platform       = :ios, '7.0'
+
   s.source          = { :git => "https://github.com/christopherdro/react-native-print", :tag => "v#{s.version}" }
   s.source_files    = 'ios/**/*.{h,m}'
 
   s.dependency 'React'
-
 end


### PR DESCRIPTION
These both settings are required to make Cocoapods for react-native-print really work 