### PR TITLE
Clear options

### DIFF
--- a/ios/RNPrint/RNPrint.m
+++ b/ios/RNPrint/RNPrint.m
@@ -17,13 +17,17 @@ RCT_EXPORT_MODULE();
 RCT_EXPORT_METHOD(print:(NSDictionary *)options
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
-    
+
     if (options[@"filePath"]){
         _filePath = [RCTConvert NSString:options[@"filePath"]];
+    } else {
+        _filePath = nil;
     }
     
     if (options[@"html"]){
         _htmlString = [RCTConvert NSString:options[@"html"]];
+    } else {
+        _htmlString = nil;
     }
     
     if (options[@"printerURL"]){


### PR DESCRIPTION
[iOS] In order to use `print()` to open multiple file types in the same app flow (so different calls, one with `filePath` option, one with `html` option or viceversa) I suggest to clear options like so