### PR TITLE
Remove overridden method to createJSModules

### DIFF
--- a/android/src/main/java/com/christopherdro/RNPrint/RNPrintPackage.java
+++ b/android/src/main/java/com/christopherdro/RNPrint/RNPrintPackage.java
@@ -24,11 +24,6 @@ public class RNPrintPackage implements ReactPackage {
   }
 
   @Override
-  public List<Class<? extends JavaScriptModule>> createJSModules() {
-  	return Collections.emptyList();
-  }
-
-  @Override
   public List<ViewManager> createViewManagers(
                             ReactApplicationContext reactContext) {
   	return Collections.emptyList();


### PR DESCRIPTION
This allows the module to compile cleanly on the newest versions of react-native/android