### PR TITLE
Use the react-native version of the project

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,5 +16,5 @@ android {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:0.20.+'
+    implementation "com.facebook.react:react-native:+" // From node_modules
 }


### PR DESCRIPTION
Instead of specifying a RN version ourselves, we should inherit it from the project.
This fixes building Android on the latest version of RN.