### PR TITLE
Don't publish any JetBrains related files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,8 @@
 example
+
+# JetBrains
+.idea
+.project
+.settings
+.idea/*
+*.iml


### PR DESCRIPTION
In your latest release 0.6.0 there is a .iml file being published that references the example project that you have ignored from being published. This results in Android studio not being able to do a successful gradle sync.

You should read the following to see how .gitignore and .npmignore work: http://npm.github.io/publishing-pkgs-docs/publishing/the-npmignore-file.html