### PR TITLE
Add android/build to npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,3 +6,6 @@ example/
 .settings
 .idea/*
 *.iml
+
+# Android build files
+android/build/


### PR DESCRIPTION
The android build folder is included in the package, it's 55MB. The rest of the package is 176KB.