### PR TITLE
fix: Xcode 12 compatibility

### DIFF
--- a/react-native-print.podspec
+++ b/react-native-print.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
   s.source          = { :git => "https://github.com/christopherdro/react-native-print", :tag => "v#{s.version}" }
   s.source_files    = 'ios/**/*.{h,m}'
 
-  s.dependency 'React'
+  s.dependency 'React-Core'
 end


### PR DESCRIPTION
# Summary

Latest Xcode 12 fails to build while without a module to depend on React-Core directly hence this change is necessary for all native modules on iOS. This change requires React Native 0.60.2 or newer. For more details please check: facebook/react-native#29633 (comment)