### PR TITLE
Fixed jobName (android)

### DIFF
--- a/android/src/main/java/com/christopherdro/RNPrint/RNPrintModule.java
+++ b/android/src/main/java/com/christopherdro/RNPrint/RNPrintModule.java
@@ -92,7 +92,7 @@ public class RNPrintModule extends ReactContextBaseJavaModule {
                                 // Create a wrapper PrintDocumentAdapter to clean up when done.
                                 PrintDocumentAdapter adapter = new PrintDocumentAdapter() {
                                     private final PrintDocumentAdapter mWrappedInstance =
-                                    mWebView.createPrintDocumentAdapter();
+                                    mWebView.createPrintDocumentAdapter(jobName);
                                     @Override
                                     public void onStart() {
                                         mWrappedInstance.onStart();


### PR DESCRIPTION
Fixes
- print jobName. Precisely the name of the file to be saved. Currently, it defaults to the name "default".