### PR TITLE
iOS jobName support

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ const styles = StyleSheet.create({
 | `filePath` | `string` | Local or remote file url NOTE: iOS only supports https protocols for remote
 | `printerURL` | `string` | **iOS Only:** URL returned from `selectPrinterMethod()`
 | `isLandscape` | `bool` | Landscape print; default value is false
-| `jobName` | `string` | **Android Only:** Name of printing job; default value is "Document"
+| `jobName` | `string` | **iOS and Android Only:** Name of printing job; default value is "Document"
 
 
 ## selectPrinter(options: Object)

--- a/ios/RNPrint/RNPrint.h
+++ b/ios/RNPrint/RNPrint.h
@@ -9,6 +9,7 @@
 @property UIPrinter *pickedPrinter;
 @property NSString *filePath;
 @property NSString *htmlString;
+@property NSString *jobName;
 @property NSURL *printerURL;
 @property (nonatomic, assign) BOOL isLandscape;
 @end

--- a/ios/RNPrint/RNPrint.m
+++ b/ios/RNPrint/RNPrint.m
@@ -29,7 +29,7 @@ RCT_EXPORT_MODULE();
     UIPrintInfo *printInfo = [UIPrintInfo printInfo];
     
     printInfo.outputType = UIPrintInfoOutputGeneral;
-    printInfo.jobName = [_filePath lastPathComponent];
+    printInfo.jobName = _jobName;
     printInfo.duplex = UIPrintInfoDuplexLongEdge;
     printInfo.orientation = _isLandscape? UIPrintInfoOrientationLandscape: UIPrintInfoOrientationPortrait;
     
@@ -93,6 +93,12 @@ RCT_EXPORT_METHOD(print:(NSDictionary *)options
     
     if(options[@"isLandscape"]) {
         _isLandscape = [[RCTConvert NSNumber:options[@"isLandscape"]] boolValue];
+    }
+
+    if(options[@"jobName"]) {
+        _jobName = [RCTConvert NSString:options[@"jobName"]];
+    } else {
+        _jobName = @"Document";
     }
     
     if ((_filePath && _htmlString) || (_filePath == nil && _htmlString == nil)) {


### PR DESCRIPTION
Added
- Support for jobName on iOS. Now a custom jobName can be supplied via RN for iOS. Currently it defaults to the {appName}.