### PR TITLE
iOS WebView and baseUrl Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,8 @@ const styles = StyleSheet.create({
 | `printerURL` | `string` | **iOS Only:** URL returned from `selectPrinterMethod()`
 | `isLandscape` | `bool` | Landscape print; default value is false
 | `jobName` | `string` | **iOS and Android Only:** Name of printing job; default value is "Document"
-| `baseUrl` | `string` | **Android Only:** Used to resolve relative links in the HTML. Also used for the origin header when applying same origin policy (CORS). Reference [Android WebView Docs](https://developer.android.com/reference/android/webkit/WebView#loadDataWithBaseURL(java.lang.String,%20java.lang.String,%20java.lang.String,%20java.lang.String,%20java.lang.String))
+| `baseUrl` | `string` | **iOS(only with useWebView) and Android Only:** Used to resolve relative links in the HTML. Also used for the origin header when applying same origin policy (CORS). Reference [iOS WebView Docs](https://developer.apple.com/documentation/webkit/wkwebview/1415004-loadhtmlstring), [Android WebView Docs](https://developer.android.com/reference/android/webkit/WebView#loadDataWithBaseURL(java.lang.String,%20java.lang.String,%20java.lang.String,%20java.lang.String,%20java.lang.String))
+| `useWebView` | `bool` | **iOS only:** Use WebView as print formatter. Android uses webview by default.
 
 
 ## selectPrinter(options: Object)

--- a/README.md
+++ b/README.md
@@ -216,8 +216,7 @@ const styles = StyleSheet.create({
 | `printerURL` | `string` | **iOS Only:** URL returned from `selectPrinterMethod()`
 | `isLandscape` | `bool` | Landscape print; default value is false
 | `jobName` | `string` | **iOS and Android Only:** Name of printing job; default value is "Document"
-| `baseUrl` | `string` | **iOS(only with useWebView) and Android Only:** Used to resolve relative links in the HTML. Also used for the origin header when applying same origin policy (CORS). Reference [iOS WebView Docs](https://developer.apple.com/documentation/webkit/wkwebview/1415004-loadhtmlstring), [Android WebView Docs](https://developer.android.com/reference/android/webkit/WebView#loadDataWithBaseURL(java.lang.String,%20java.lang.String,%20java.lang.String,%20java.lang.String,%20java.lang.String))
-| `useWebView` | `bool` | **iOS only:** Use WebView as print formatter. Android uses webview by default.
+| `baseUrl` | `string` | **iOS and Android Only:** Used to resolve relative links in the HTML. Also used for the origin header when applying same origin policy (CORS). Reference [iOS WebView Docs](https://developer.apple.com/documentation/webkit/wkwebview/1415004-loadhtmlstring), [Android WebView Docs](https://developer.android.com/reference/android/webkit/WebView#loadDataWithBaseURL(java.lang.String,%20java.lang.String,%20java.lang.String,%20java.lang.String,%20java.lang.String))
 
 
 ## selectPrinter(options: Object)

--- a/ios/RNPrint/RNPrint.h
+++ b/ios/RNPrint/RNPrint.h
@@ -11,5 +11,7 @@
 @property NSString *htmlString;
 @property NSString *jobName;
 @property NSURL *printerURL;
+@property NSURL *baseUrl;
 @property (nonatomic, assign) BOOL isLandscape;
+@property (nonatomic, assign) BOOL useWebView;
 @end

--- a/ios/RNPrint/RNPrint.h
+++ b/ios/RNPrint/RNPrint.h
@@ -13,5 +13,4 @@
 @property NSURL *printerURL;
 @property NSURL *baseUrl;
 @property (nonatomic, assign) BOOL isLandscape;
-@property (nonatomic, assign) BOOL useWebView;
 @end

--- a/ios/RNPrint/RNPrint.m
+++ b/ios/RNPrint/RNPrint.m
@@ -42,7 +42,7 @@ RCT_EXPORT_MODULE();
     printInteractionController.printInfo = printInfo;
     printInteractionController.showsPageRange = YES;
     
-    if (_useWebView) {
+    if (_baseUrl) {
         printInteractionController.printFormatter = _webView.viewPrintFormatter;
     } else if (_htmlString) {
         UIMarkupTextPrintFormatter *formatter = [[UIMarkupTextPrintFormatter alloc] initWithMarkupText:_htmlString];
@@ -142,10 +142,6 @@ RCT_EXPORT_METHOD(print:(NSDictionary *)options
         _baseUrl = [NSURL URLWithString:options[@"baseUrl"]];
     }
     
-    if (options[@"useWebView"]) {
-        _useWebView = [[RCTConvert NSNumber:options[@"useWebView"]] boolValue];
-    }
-    
     if ((_filePath && _htmlString) || (_filePath == nil && _htmlString == nil)) {
         reject(RCTErrorUnspecified, nil, RCTErrorWithMessage(@"Must provide either `html` or `filePath`. Both are either missing or passed together"));
     }
@@ -153,7 +149,7 @@ RCT_EXPORT_METHOD(print:(NSDictionary *)options
     _resolve = resolve;
     _reject = reject;
     
-    if (_useWebView) {
+    if (_baseUrl) {
         _webView = [[WKWebView alloc] initWithFrame:self.bounds];
         _webView.navigationDelegate = self;
         [self addSubview:_webView];


### PR DESCRIPTION
Solves an issue on iOS to load relative links(images, styles) and CORS.

Fixes #164 #159

Added params to the print method
- baseUrl (new for iOS)
- useWebView (iOS only)

We can fully switch to using WebView in the next version if no issues are found.