### PR TITLE
Bugfix: x and y are number not string

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5,8 +5,8 @@ type PrintOptionsType = {
 } & ({ html: string } | { filePath: string });
 
 type SelectPrinterOptionsType = {
-	x: string;
-	y: string;
+	x: number;
+	y: number;
 };
 
 export function print(options: PrintOptionsType): Promise<any>;


### PR DESCRIPTION
The readme shows numbers for x and y, but the types require strings.

I tried supplying strings to see if that was the correct option, but this raised an exception, so I believe that the parameters should be number and not string.