### PR TITLE
Add return type to selectPrinter types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -9,6 +9,11 @@ type SelectPrinterOptionsType = {
 	y: string;
 };
 
+type SelectPrinterReturnType = {
+	name: string;
+	url: string;
+}
+
 export function print(options: PrintOptionsType): Promise<any>;
 
-export function selectPrinter(options: SelectPrinterOptionsType): Promise<any>;
+export function selectPrinter(options: SelectPrinterOptionsType): Promise<SelectPrinterReturnType>;


### PR DESCRIPTION
The return type here is based on my tests on iOS and console.log(), so I'm not sure if this is consistent across platforms, etc. We're only working on iOS so these types work for me.